### PR TITLE
Remove pthread check when building with depends (cross compiling)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -222,23 +222,6 @@ if (WIN32)
       ws2_32)
 endif ()
 
-if (MINGW)
-  # There is no variable for this (probably due to the fact that the pthread
-  # library is implicit with a link in msys).
-  find_library(win32pthread
-    NAMES libwinpthread-1.dll)
-  foreach (input IN LISTS win32pthread OPENSSL_LIBRARIES)
-    # Copy shared libraries into the build tree so that no PATH manipulation is
-    # necessary.
-    get_filename_component(name "${input}" NAME)
-    configure_file(
-      "${input}"
-      "${CMAKE_BINARY_DIR}/bin/${name}"
-      COPYONLY)
-  endforeach ()
-endif ()
-
-
 if (INSTALL_VENDORED_LIBUNBOUND)
     if(IOS)
         set(lib_folder lib-${ARCH})


### PR DESCRIPTION
When cross compiling with mingw, the pthread dll is not used. 