### PR TITLE
Remove glob to preserve binary back compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -231,3 +231,7 @@ if (INSTALL_VENDORED_LIBUNBOUND)
     install(TARGETS unbound
         ARCHIVE DESTINATION ${lib_folder})
 endif()
+
+if (BACKCOMPAT)
+    add_definitions(-DBACK_COMPAT)
+endif()

--- a/util/config_file.c
+++ b/util/config_file.c
@@ -59,6 +59,13 @@
 #include "services/cache/infra.h"
 #include "sldns/wire2str.h"
 #include "sldns/parseutil.h"
+
+//For glibc back-compat pruposes, glob is turned off
+#ifdef BACK_COMPAT
+#undef HAVE_GLOB
+#undef HAVE_GLOB_H
+#endif
+
 #ifdef HAVE_GLOB_H
 # include <glob.h>
 #endif

--- a/util/configlexer.c
+++ b/util/configlexer.c
@@ -2478,6 +2478,11 @@ char *yytext;
 
 #include <ctype.h>
 #include <strings.h>
+#ifdef BACK_COMPAT
+#undef HAVE_GLOB
+#undef HAVE_GLOB_H
+#endif
+
 #ifdef HAVE_GLOB_H
 # include <glob.h>
 #endif

--- a/util/configlexer.lex
+++ b/util/configlexer.lex
@@ -15,6 +15,12 @@
 
 #include <ctype.h>
 #include <strings.h>
+
+#ifdef BACK_COMPAT
+#undef HAVE_GLOB
+#undef HAVE_GLOB_H
+#endif
+
 #ifdef HAVE_GLOB_H
 # include <glob.h>
 #endif

--- a/validator/val_anchor.c
+++ b/validator/val_anchor.c
@@ -52,6 +52,12 @@
 #include "sldns/sbuffer.h"
 #include "sldns/rrdef.h"
 #include "sldns/str2wire.h"
+
+#ifdef BACK_COMPAT
+#undef HAVE_GLOB
+#undef HAVE_GLOB_H
+#endif
+
 #ifdef HAVE_GLOB_H
 #include <glob.h>
 #endif


### PR DESCRIPTION
Glob links with gnu libc version 2.27 if compiled on a modern system. This is due to the vulnerabilities found in its libc implementation, particularly CVE-2017-15670-1. This could lead to a buffer overflow if a
`~` operator is used. Since glob is not directly used by monero, removing support for it seems to be the simplest way to deal with this in order to preserve binary compatibility accross a range of linux distributions. Together with the back compatibility code for monero this should set the required libc version at 2.17.
Please see discussion and comments on https://github.com/monero-project/monero/pull/4929 before merging.