### PR TITLE
build: fix static builds

### DIFF
--- a/configure_checks.cmake
+++ b/configure_checks.cmake
@@ -202,10 +202,10 @@ check_symbol_exists(NID_X9_62_prime256v1 "openssl/evp.h" HAVE_DECL_NID_X9_62_PRI
 check_symbol_exists(sk_SSL_COMP_pop_free "openssl/ssl.h" HAVE_DECL_SK_SSL_COMP_POP_FREE)
 check_symbol_exists(SSL_COMP_get_compression_methods "openssl/ssl.h" HAVE_DECL_SSL_COMP_GET_COMPRESSION_METHODS)
 
-check_function_exists(EVP_MD_CTX_new HAVE_EVP_MD_CTX_NEW)
+set(HAVE_EVP_MD_CTX_NEW 1)
 check_function_exists(EVP_sha1 HAVE_EVP_SHA1)
-check_function_exists(EVP_sha256 HAVE_EVP_SHA256)
-check_function_exists(EVP_sha512 HAVE_EVP_SHA512)
+set(HAVE_EVP_SHA256 1)
+set(HAVE_EVP_SHA512 1)
 check_function_exists(FIPS_mode HAVE_FIPS_MODE)
 check_function_exists(HMAC_Update HAVE_HMAC_UPDATE)
 check_function_exists(OPENSSL_config HAVE_OPENSSL_CONFIG)


### PR DESCRIPTION
Fixes this error:
invalid application of 'sizeof' to an incomplete type 'EVP_MD_CTX' (aka 'struct evp_md_ctx_st')